### PR TITLE
🐳 Added dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:latest
+RUN gem install halidator
+CMD halidate


### PR DESCRIPTION
Allows halidate to be run as a docker container:
> docker build . -t halidate
> http example.com/hal | docker run -i halidate